### PR TITLE
Create demo of --project issues for issue report

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "karma start --reporters mocha,junit --single-run --browsers PhantomJS",
-    "build-lib": "tsc -v&&cd ./src/lib&&tsc&&cd ../../",
+    "build-lib": "tsc -v&&tsc --project ./src/lib",
     "watch-demo": "gulp watch",
     "build-demo": "gulp build"
   },

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -10,9 +10,7 @@
         "removeComments": false,
         "preserveConstEnums": true,
         "sourceMap": false,
-        "outDir": "../../",
-        "listFiles": true,
-        "diagnostics": true
+        "outDir": "../../"
     },
     "files": [
         "index.ts"

--- a/src/lib/tsconfig.json
+++ b/src/lib/tsconfig.json
@@ -10,7 +10,9 @@
         "removeComments": false,
         "preserveConstEnums": true,
         "sourceMap": false,
-        "outDir": "../../"
+        "outDir": "../../",
+        "listFiles": true,
+        "diagnostics": true
     },
     "files": [
         "index.ts"


### PR DESCRIPTION
The `outDir` is not being respected. Files are being generated in the project working directory rather than in `../../` as instructed in the `tsconfig.json`.

So rather than ending up with `index.js` and `index.d.ts` in the root, they are placed in the same directory as the `tsconfig.json`.
